### PR TITLE
Use thiserror instead of anyhow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,16 +11,17 @@ repository = "https://github.com/yannickfunk/genanki-rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rusqlite = { version="0.25.1", features=["bundled"] }
+rusqlite = { version = "0.25.1", features = ["bundled"] }
 tempfile = "3.2.0"
 zip = "0.5.12"
 serde_json = "1.0.64"
-anyhow = "1.0.40"
 fancy-regex = "0.5.0"
 serde = { version = "1.0", features = ["derive"] }
 ramhorns = "0.10.2"
+thiserror = "1.0.32"
 
 [dev-dependencies]
+anyhow = "1.0.62"
 pyo3 = "0.13.2"
 serial_test = "0.5.1"
 uuid = { version = "0.8", features = ["v4"] }

--- a/src/card.rs
+++ b/src/card.rs
@@ -1,7 +1,7 @@
 use rusqlite::{params, Transaction};
 use std::ops::RangeFrom;
 
-use crate::Error;
+use crate::{error::database_error, Error};
 
 #[derive(Clone)]
 pub struct Card {
@@ -26,29 +26,31 @@ impl Card {
         id_gen: &mut RangeFrom<usize>,
     ) -> Result<(), Error> {
         let queue = if self.suspend { -1 } else { 0 };
-        transaction.execute(
-            "INSERT INTO cards VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?);",
-            params![
-                id_gen.next(),    // id
-                note_id,          // nid
-                deck_id,          // did
-                self.ord,         // ord
-                timestamp as i64, // mod
-                -1,               // usn
-                0,                // type (=0 for non-Cloze)
-                queue,            // queue
-                0,                // due
-                0,                // ivl
-                0,                // factor
-                0,                // reps
-                0,                // lapses
-                0,                // left
-                0,                // odue
-                0,                // odid
-                0,                // flags
-                "",               // data
-            ],
-        )?;
+        transaction
+            .execute(
+                "INSERT INTO cards VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?);",
+                params![
+                    id_gen.next(),    // id
+                    note_id,          // nid
+                    deck_id,          // did
+                    self.ord,         // ord
+                    timestamp as i64, // mod
+                    -1,               // usn
+                    0,                // type (=0 for non-Cloze)
+                    queue,            // queue
+                    0,                // due
+                    0,                // ivl
+                    0,                // factor
+                    0,                // reps
+                    0,                // lapses
+                    0,                // left
+                    0,                // odue
+                    0,                // odid
+                    0,                // flags
+                    "",               // data
+                ],
+            )
+            .map_err(database_error)?;
         Ok(())
     }
 }

--- a/src/card.rs
+++ b/src/card.rs
@@ -1,6 +1,8 @@
 use rusqlite::{params, Transaction};
 use std::ops::RangeFrom;
 
+use crate::Error;
+
 #[derive(Clone)]
 pub struct Card {
     pub ord: i64,
@@ -22,7 +24,7 @@ impl Card {
         deck_id: usize,
         note_id: usize,
         id_gen: &mut RangeFrom<usize>,
-    ) -> Result<(), anyhow::Error> {
+    ) -> Result<(), Error> {
         let queue = if self.suspend { -1 } else { 0 };
         transaction.execute(
             "INSERT INTO cards VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?);",

--- a/src/deck.rs
+++ b/src/deck.rs
@@ -1,5 +1,6 @@
 use super::Package;
 use crate::db_entries::{DeckDbEntry, ModelDbEntry};
+use crate::error::{database_error, json_error};
 use crate::model::Model;
 use crate::note::Note;
 use crate::Error;
@@ -80,28 +81,36 @@ impl Deck {
         timestamp: f64,
         id_gen: &mut RangeFrom<usize>,
     ) -> Result<(), Error> {
-        let decks_json_str: String =
-            transaction.query_row("SELECT decks FROM col", [], |row| row.get(0))?;
-        let mut decks: HashMap<usize, DeckDbEntry> = serde_json::from_str(&decks_json_str)?;
+        let decks_json_str: String = transaction
+            .query_row("SELECT decks FROM col", [], |row| row.get(0))
+            .map_err(database_error)?;
+        let mut decks: HashMap<usize, DeckDbEntry> =
+            serde_json::from_str(&decks_json_str).map_err(json_error)?;
         decks.insert(self.id, self.to_deck_db_entry());
-        transaction.execute(
-            "UPDATE col SET decks = ?",
-            params![serde_json::to_string(&decks)?],
-        )?;
+        transaction
+            .execute(
+                "UPDATE col SET decks = ?",
+                params![serde_json::to_string(&decks).map_err(json_error)?],
+            )
+            .map_err(database_error)?;
 
-        let models_json_str: String =
-            transaction.query_row("SELECT models FROM col", [], |row| row.get(0))?;
-        let mut models: HashMap<usize, ModelDbEntry> = serde_json::from_str(&models_json_str)?;
+        let models_json_str: String = transaction
+            .query_row("SELECT models FROM col", [], |row| row.get(0))
+            .map_err(database_error)?;
+        let mut models: HashMap<usize, ModelDbEntry> =
+            serde_json::from_str(&models_json_str).map_err(json_error)?;
         for note in self.notes.clone().iter() {
             self.add_model(note.model());
         }
         for (i, model) in &mut self.models {
             models.insert(*i, model.to_model_db_entry(timestamp, self.id)?);
         }
-        transaction.execute(
-            "UPDATE col SET models = ?",
-            [serde_json::to_string(&models)?],
-        )?;
+        transaction
+            .execute(
+                "UPDATE col SET models = ?",
+                [serde_json::to_string(&models).map_err(json_error)?],
+            )
+            .map_err(database_error)?;
         for note in &mut self.notes {
             note.write_to_db(&transaction, timestamp, self.id, id_gen)?;
         }

--- a/src/deck.rs
+++ b/src/deck.rs
@@ -2,6 +2,7 @@ use super::Package;
 use crate::db_entries::{DeckDbEntry, ModelDbEntry};
 use crate::model::Model;
 use crate::note::Note;
+use crate::Error;
 use rusqlite::{params, Transaction};
 use std::collections::HashMap;
 use std::ops::RangeFrom;
@@ -78,7 +79,7 @@ impl Deck {
         transaction: &Transaction,
         timestamp: f64,
         id_gen: &mut RangeFrom<usize>,
-    ) -> Result<(), anyhow::Error> {
+    ) -> Result<(), Error> {
         let decks_json_str: String =
             transaction.query_row("SELECT decks FROM col", [], |row| row.get(0))?;
         let mut decks: HashMap<usize, DeckDbEntry> = serde_json::from_str(&decks_json_str)?;
@@ -130,7 +131,7 @@ impl Deck {
     ///
     /// Package::new(vec![my_deck], vec![])?.write_to_file("output.apkg")?;
     /// ```
-    pub fn write_to_file(&self, file: &str) -> Result<(), anyhow::Error> {
+    pub fn write_to_file(&self, file: &str) -> Result<(), Error> {
         Package::new(vec![self.clone()], vec![])?.write_to_file(file)?;
         Ok(())
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,75 @@
+use std::{convert::Infallible, time::SystemTimeError};
+
+use zip::result::ZipError;
+
+use crate::db_entries::Tmpl;
+
+#[derive(thiserror::Error, Debug)]
+#[non_exhaustive]
+pub enum Error {
+    /// Indicates an error happened with the database layer
+    ///
+    /// Currently the argument is a `rusqlite::Error`, but it is
+    /// cast to a Box<dyn std::error::Error> so that we can change
+    /// the underlying library in the future if needed without breaking
+    /// client code.
+    #[error(transparent)]
+    Database(Box<dyn std::error::Error>),
+    /// Indicates an error happened with the JSON parser
+    ///
+    /// Currently the argument is a `serde_json::Error`, but it is
+    /// cast to a Box<dyn std::error::Error> so that we can change
+    /// the underlying library in the future if needed without breaking
+    /// client code.
+    #[error(transparent)]
+    JsonParser(Box<dyn std::error::Error>),
+    #[error("Could not compute required fields for this template; please check the formatting of \"qfmt\": {0:?}")]
+    TemplateFormat(Tmpl),
+    #[error("number of model field ({0}) does not match number of fields ({1})")]
+    ModelFieldCountMismatch(usize, usize),
+    #[error("One of the tags contains whitespace, this is not allowed!")]
+    TagContainsWhitespace,
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    /// Indicates an error with the underlying template system
+    ///
+    /// Currently the argument is a `ramhorns::Error`, but it is
+    /// cast to a Box<dyn std::error::Error> so that we can change
+    /// the underlying library in the future if needed without breaking
+    /// client code.
+    #[error(transparent)]
+    Template(#[from] Box<dyn std::error::Error>),
+    #[error(transparent)]
+    SystemTime(#[from] SystemTimeError),
+    /// Indicates an error with zip file handling
+    ///
+    /// Currently the argument is a `zip::result::ZipError`, but it is
+    /// cast to a Box<dyn std::error::Error> so that we can change
+    /// the underlying library in the future if needed without breaking
+    /// client code.
+    #[error(transparent)]
+    Zip(Box<dyn std::error::Error>),
+}
+
+impl From<Infallible> for Error {
+    fn from(_: Infallible) -> Self {
+        // Infallible is uninhabited, so there's no way we can get to this code.
+        unreachable!()
+    }
+}
+
+pub(crate) fn database_error(e: rusqlite::Error) -> Error {
+    Error::Template(Box::new(e))
+}
+
+pub(crate) fn json_error(e: serde_json::Error) -> Error {
+    Error::Template(Box::new(e))
+}
+
+pub(crate) fn template_error(e: ramhorns::Error) -> Error {
+    Error::Template(Box::new(e))
+}
+
+pub(crate) fn zip_error(e: ZipError) -> Error {
+    Error::Zip(Box::new(e))
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,6 +4,10 @@ use zip::result::ZipError;
 
 use crate::db_entries::Tmpl;
 
+// Make sure `Error` is `Send`
+const fn _assert_send<T: Send>() {}
+const _: () = _assert_send::<Error>();
+
 #[derive(thiserror::Error, Debug)]
 #[non_exhaustive]
 pub enum Error {
@@ -14,7 +18,7 @@ pub enum Error {
     /// the underlying library in the future if needed without breaking
     /// client code.
     #[error(transparent)]
-    Database(Box<dyn std::error::Error>),
+    Database(Box<dyn std::error::Error + Send>),
     /// Indicates an error happened with the JSON parser
     ///
     /// Currently the argument is a `serde_json::Error`, but it is
@@ -22,7 +26,7 @@ pub enum Error {
     /// the underlying library in the future if needed without breaking
     /// client code.
     #[error(transparent)]
-    JsonParser(Box<dyn std::error::Error>),
+    JsonParser(Box<dyn std::error::Error + Send>),
     #[error("Could not compute required fields for this template; please check the formatting of \"qfmt\": {0:?}")]
     TemplateFormat(Tmpl),
     #[error("number of model field ({0}) does not match number of fields ({1})")]
@@ -38,7 +42,7 @@ pub enum Error {
     /// the underlying library in the future if needed without breaking
     /// client code.
     #[error(transparent)]
-    Template(#[from] Box<dyn std::error::Error>),
+    Template(#[from] Box<dyn std::error::Error + Send>),
     #[error(transparent)]
     SystemTime(#[from] SystemTimeError),
     /// Indicates an error with zip file handling
@@ -48,7 +52,7 @@ pub enum Error {
     /// the underlying library in the future if needed without breaking
     /// client code.
     #[error(transparent)]
-    Zip(Box<dyn std::error::Error>),
+    Zip(Box<dyn std::error::Error + Send>),
 }
 
 impl From<Infallible> for Error {

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,9 +4,11 @@ use zip::result::ZipError;
 
 use crate::db_entries::Tmpl;
 
-// Make sure `Error` is `Send`
+// Make sure `Error` is `Send` and `Sync`
 const fn _assert_send<T: Send>() {}
+const fn _assert_sync<T: Sync>() {}
 const _: () = _assert_send::<Error>();
+const _: () = _assert_sync::<Error>();
 
 #[derive(thiserror::Error, Debug)]
 #[non_exhaustive]
@@ -18,7 +20,7 @@ pub enum Error {
     /// the underlying library in the future if needed without breaking
     /// client code.
     #[error(transparent)]
-    Database(Box<dyn std::error::Error + Send>),
+    Database(Box<dyn std::error::Error + Send + Sync>),
     /// Indicates an error happened with the JSON parser
     ///
     /// Currently the argument is a `serde_json::Error`, but it is
@@ -26,7 +28,7 @@ pub enum Error {
     /// the underlying library in the future if needed without breaking
     /// client code.
     #[error(transparent)]
-    JsonParser(Box<dyn std::error::Error + Send>),
+    JsonParser(Box<dyn std::error::Error + Send + Sync>),
     #[error("Could not compute required fields for this template; please check the formatting of \"qfmt\": {0:?}")]
     TemplateFormat(Tmpl),
     #[error("number of model field ({0}) does not match number of fields ({1})")]
@@ -42,7 +44,7 @@ pub enum Error {
     /// the underlying library in the future if needed without breaking
     /// client code.
     #[error(transparent)]
-    Template(#[from] Box<dyn std::error::Error + Send>),
+    Template(#[from] Box<dyn std::error::Error + Send + Sync>),
     #[error(transparent)]
     SystemTime(#[from] SystemTimeError),
     /// Indicates an error with zip file handling
@@ -52,7 +54,7 @@ pub enum Error {
     /// the underlying library in the future if needed without breaking
     /// client code.
     #[error(transparent)]
-    Zip(Box<dyn std::error::Error + Send>),
+    Zip(Box<dyn std::error::Error + Send + Sync>),
 }
 
 impl From<Infallible> for Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,50 +170,19 @@ mod builtin_models;
 mod card;
 mod db_entries;
 mod deck;
+mod error;
 mod model;
 mod note;
 mod package;
 mod util;
 
-use std::{convert::Infallible, time::SystemTimeError};
-
 pub use builders::{Field, Template};
 pub use builtin_models::*;
 pub use deck::Deck;
+pub use error::Error;
 pub use model::{Model, ModelType};
 pub use note::Note;
 pub use package::Package;
-use zip::result::ZipError;
-
-#[derive(thiserror::Error, Debug)]
-#[non_exhaustive]
-pub enum Error {
-    #[error(transparent)]
-    Database(#[from] rusqlite::Error),
-    #[error(transparent)]
-    JsonParser(#[from] serde_json::Error),
-    #[error("Could not compute required fields for this template; please check the formatting of \"qfmt\": {0:?}")]
-    TemplateFormat(db_entries::Tmpl),
-    #[error("number of model field ({0}) does not match number of fields ({1})")]
-    ModelFieldCountMismatch(usize, usize),
-    #[error("One of the tags contains whitespace, this is not allowed!")]
-    TagContainsWhitespace,
-    #[error(transparent)]
-    Io(#[from] std::io::Error),
-    #[error(transparent)]
-    Template(#[from] ramhorns::Error),
-    #[error(transparent)]
-    SystemTime(#[from] SystemTimeError),
-    #[error(transparent)]
-    Zip(#[from] ZipError),
-}
-
-impl From<Infallible> for Error {
-    fn from(_: Infallible) -> Self {
-        // Infallible is uninhabited, so there's no way we can get to this code.
-        unreachable!()
-    }
-}
 
 #[cfg(test)]
 mod tests {

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,7 +1,6 @@
 use crate::builders::Template;
 use crate::db_entries::{Fld, ModelDbEntry, Tmpl};
-use crate::Field;
-use anyhow::anyhow;
+use crate::{Error, Field};
 use fancy_regex::Regex;
 use ramhorns::Template as RamTemplate;
 use std::collections::HashMap;
@@ -101,7 +100,7 @@ impl Model {
         }
     }
 
-    pub(super) fn req(&self) -> Result<Vec<(usize, String, Vec<usize>)>, anyhow::Error> {
+    pub(super) fn req(&self) -> Result<Vec<(usize, String, Vec<usize>)>, Error> {
         let sentinel = "SeNtInEl".to_string();
         let field_names: Vec<String> = self.fields.iter().map(|field| field.name.clone()).collect();
         let field_values = field_names
@@ -128,7 +127,7 @@ impl Model {
                 .map(|(field_ord, _)| field_ord)
                 .collect::<Vec<_>>();
             if required_fields.is_empty() {
-                return Err(anyhow!(format!("Could not compute required fields for this template; please check the formatting of \"qfmt\": {:?}", template)));
+                return Err(Error::TemplateFormat(template.clone()));
             }
             req.push((template_ord, "any".to_string(), required_fields))
         }
@@ -148,7 +147,7 @@ impl Model {
         &mut self,
         timestamp: f64,
         deck_id: usize,
-    ) -> Result<ModelDbEntry, anyhow::Error> {
+    ) -> Result<ModelDbEntry, Error> {
         self.templates
             .iter_mut()
             .enumerate()
@@ -182,11 +181,7 @@ impl Model {
     }
 
     #[allow(dead_code)]
-    pub(super) fn to_json(
-        &mut self,
-        timestamp: f64,
-        deck_id: usize,
-    ) -> Result<String, anyhow::Error> {
+    pub(super) fn to_json(&mut self, timestamp: f64, deck_id: usize) -> Result<String, Error> {
         Ok(serde_json::to_string(
             &self.to_model_db_entry(timestamp, deck_id)?,
         )?)

--- a/src/package.rs
+++ b/src/package.rs
@@ -11,6 +11,7 @@ use std::path::{Path, PathBuf};
 use crate::apkg_col::APKG_COL;
 use crate::apkg_schema::APKG_SCHEMA;
 use crate::deck::Deck;
+use crate::Error;
 use std::str::FromStr;
 
 /// `Package` to pack `Deck`s and `media_files` and write them to a `.apkg` file
@@ -48,7 +49,7 @@ impl Package {
     /// Create a new package with `decks` and `media_files`
     ///
     /// Returns `Err` if `media_files` are invalid
-    pub fn new(decks: Vec<Deck>, media_files: Vec<&str>) -> Result<Self, anyhow::Error> {
+    pub fn new(decks: Vec<Deck>, media_files: Vec<&str>) -> Result<Self, Error> {
         let media_files = media_files
             .iter()
             .map(|&s| PathBuf::from_str(s))
@@ -59,18 +60,14 @@ impl Package {
     /// Writes the package to a file
     ///
     /// Returns `Err` if the `file` cannot be created
-    pub fn write_to_file(&mut self, file: &str) -> Result<(), anyhow::Error> {
+    pub fn write_to_file(&mut self, file: &str) -> Result<(), Error> {
         self.write_to_file_maybe_timestamp(file, None)
     }
 
     /// Writes the package to a file using a timestamp
     ///
     /// Returns `Err` if the `file` cannot be created
-    pub fn write_to_file_timestamp(
-        &mut self,
-        file: &str,
-        timestamp: f64,
-    ) -> Result<(), anyhow::Error> {
+    pub fn write_to_file_timestamp(&mut self, file: &str, timestamp: f64) -> Result<(), Error> {
         self.write_to_file_maybe_timestamp(file, Some(timestamp))
     }
 
@@ -78,7 +75,7 @@ impl Package {
         &mut self,
         file: &str,
         timestamp: Option<f64>,
-    ) -> Result<(), anyhow::Error> {
+    ) -> Result<(), Error> {
         let file = File::create(&file)?;
         let db_file = NamedTempFile::new()?.into_temp_path();
 
@@ -129,11 +126,7 @@ impl Package {
         Ok(())
     }
 
-    fn write_to_db(
-        &mut self,
-        transaction: &Transaction,
-        timestamp: f64,
-    ) -> Result<(), anyhow::Error> {
+    fn write_to_db(&mut self, transaction: &Transaction, timestamp: f64) -> Result<(), Error> {
         let mut id_gen = ((timestamp * 1000.0) as usize)..;
         transaction.execute_batch(APKG_SCHEMA)?;
         transaction.execute_batch(APKG_COL)?;
@@ -144,7 +137,7 @@ impl Package {
     }
 }
 
-fn read_file_bytes<P: AsRef<Path>>(path: P) -> Result<Vec<u8>, anyhow::Error> {
+fn read_file_bytes<P: AsRef<Path>>(path: P) -> Result<Vec<u8>, Error> {
     let mut handle = File::open(path)?;
     let mut data = Vec::new();
     handle.read_to_end(&mut data)?;


### PR DESCRIPTION
First of all, thanks for making this crate! I needed something like this for a small project and this worked great!

That said, I wanted to use [eyre](https://crates.io/crates/eyre) for easy error handling in my project and I discovered that anyhow errors do not actually implement `std::error::Error`, which meant I had to use `unwrap` instead of `?` on any results returned by genanki-rs. These days the recommendation seems to be to use `thiserror` in library code and `anyhow` in application code, so I decided to migrate genanki-rs to use a custom error type.

While this change is a semver breaking change itself, I've tried to do this PR in a way that avoids future semver hazards around error handling. For example, instead of bubbling up errors from dependencies, I cast them to a `dyn Error` so that it would still be possible to swap out the underlying library in the future.

I'm happy to take suggestions for how errors should be named or categorized though! This is basically a straightforward attempt at translating the different error sites to an enum that indicates which error happened.

I also wasn't sure whether some of these should be errors or panics, but I left the errors as errors for now.