### PR TITLE
Use i64 for Model and Deck ids

### DIFF
--- a/src/card.rs
+++ b/src/card.rs
@@ -21,7 +21,7 @@ impl Card {
         &self,
         transaction: &Transaction,
         timestamp: f64,
-        deck_id: usize,
+        deck_id: i64,
         note_id: usize,
         id_gen: &mut RangeFrom<usize>,
     ) -> Result<(), Error> {

--- a/src/db_entries.rs
+++ b/src/db_entries.rs
@@ -12,7 +12,7 @@ pub struct DeckDbEntry {
     pub extend_new: i64,
     #[serde(rename = "extendRev")]
     pub extend_rev: i64,
-    pub id: usize,
+    pub id: i64,
     #[serde(rename = "lrnToday")]
     pub lrn_today: Vec<i64>,
     #[serde(rename = "mod")]
@@ -38,7 +38,7 @@ pub struct ModelDbEntry {
     pub vers: Vec<Option<serde_json::Value>>,
     pub name: String,
     pub tags: Vec<Option<serde_json::Value>>,
-    pub did: usize,
+    pub did: i64,
     pub usn: i64,
     pub req: Vec<(usize, String, Vec<usize>)>,
     pub flds: Vec<Fld>,

--- a/src/deck.rs
+++ b/src/deck.rs
@@ -15,7 +15,7 @@ pub struct Deck {
     name: String,
     description: String,
     notes: Vec<Note>,
-    models: HashMap<usize, Model>,
+    models: HashMap<i64, Model>,
 }
 
 impl Deck {
@@ -97,7 +97,7 @@ impl Deck {
         let models_json_str: String = transaction
             .query_row("SELECT models FROM col", [], |row| row.get(0))
             .map_err(database_error)?;
-        let mut models: HashMap<usize, ModelDbEntry> =
+        let mut models: HashMap<i64, ModelDbEntry> =
             serde_json::from_str(&models_json_str).map_err(json_error)?;
         for note in self.notes.clone().iter() {
             self.add_model(note.model());

--- a/src/deck.rs
+++ b/src/deck.rs
@@ -11,7 +11,7 @@ use std::ops::RangeFrom;
 /// A flashcard deck which can be written into an .apkg file.
 #[derive(Clone)]
 pub struct Deck {
-    id: usize,
+    id: i64,
     name: String,
     description: String,
     notes: Vec<Note>,
@@ -22,7 +22,7 @@ impl Deck {
     /// Creates a new deck with an `id`, `name` and `description`.
     ///
     /// `id` should always be unique when creating multiple decks.
-    pub fn new(id: usize, name: &str, description: &str) -> Self {
+    pub fn new(id: i64, name: &str, description: &str) -> Self {
         Self {
             id,
             name: name.to_string(),
@@ -84,7 +84,7 @@ impl Deck {
         let decks_json_str: String = transaction
             .query_row("SELECT decks FROM col", [], |row| row.get(0))
             .map_err(database_error)?;
-        let mut decks: HashMap<usize, DeckDbEntry> =
+        let mut decks: HashMap<i64, DeckDbEntry> =
             serde_json::from_str(&decks_json_str).map_err(json_error)?;
         decks.insert(self.id, self.to_deck_db_entry());
         transaction

--- a/src/model.rs
+++ b/src/model.rs
@@ -30,7 +30,7 @@ pub enum ModelType {
 /// `Model` to determine the structure of a `Note`
 #[derive(Clone)]
 pub struct Model {
-    pub id: usize,
+    pub id: i64,
     name: String,
     fields: Vec<Fld>,
     templates: Vec<Tmpl>,
@@ -57,7 +57,7 @@ impl Model {
     ///         .afmt(r#"{{FrontSide}}<hr id="answer">{{Answer}}"#)],
     /// );
     /// ```
-    pub fn new(id: usize, name: &str, fields: Vec<Field>, templates: Vec<Template>) -> Self {
+    pub fn new(id: i64, name: &str, fields: Vec<Field>, templates: Vec<Template>) -> Self {
         Self {
             id,
             name: name.to_string(),
@@ -79,7 +79,7 @@ impl Model {
     /// * `sort_field_index`: Custom sort field index
     #[allow(clippy::too_many_arguments)]
     pub fn new_with_options(
-        id: usize,
+        id: i64,
         name: &str,
         fields: Vec<Field>,
         templates: Vec<Template>,

--- a/src/model.rs
+++ b/src/model.rs
@@ -198,7 +198,7 @@ impl Model {
     pub(super) fn to_model_db_entry(
         &mut self,
         timestamp: f64,
-        deck_id: usize,
+        deck_id: i64,
     ) -> Result<ModelDbEntry, Error> {
         self.templates
             .iter_mut()
@@ -233,7 +233,7 @@ impl Model {
     }
 
     #[allow(dead_code)]
-    pub(super) fn to_json(&mut self, timestamp: f64, deck_id: usize) -> Result<String, Error> {
+    pub(super) fn to_json(&mut self, timestamp: f64, deck_id: i64) -> Result<String, Error> {
         Ok(
             serde_json::to_string(&self.to_model_db_entry(timestamp, deck_id)?)
                 .map_err(json_error)?,

--- a/src/note.rs
+++ b/src/note.rs
@@ -160,7 +160,7 @@ impl Note {
         &self,
         transaction: &Transaction,
         timestamp: f64,
-        deck_id: usize,
+        deck_id: i64,
         mut id_gen: &mut RangeFrom<usize>,
     ) -> Result<(), Error> {
         self.check_number_model_fields_matches_num_fields()?;

--- a/src/note.rs
+++ b/src/note.rs
@@ -285,7 +285,7 @@ mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
     use tempfile::{NamedTempFile, TempPath};
 
-    fn write_to_db_setup(db_file: &TempPath) -> (Connection, f64, usize, RangeFrom<usize>) {
+    fn write_to_db_setup(db_file: &TempPath) -> (Connection, f64, i64, RangeFrom<usize>) {
         let conn = Connection::open(&db_file).unwrap();
         conn.execute_batch(APKG_SCHEMA).unwrap();
         conn.execute_batch(APKG_COL).unwrap();


### PR DESCRIPTION
Hi,
Thanks for your work on genanki-rs.

I got an error when using a randomly generated Model id because it was too large (`out of range integral type conversion attempted`). The error occurred here:

https://github.com/yannickfunk/genanki-rs/blob/6ddffe94be05e34c15053eb130c837c304b43b33/src/note.rs#L168-L185

I was also able to reproduce a similar error by trying to use a large Deck id. It seems like the cause is that the integer used in SQLite is an i64. Anki doesn't seem to mind negative model or deck ids, so this PR changes the ids to be i64 to avoid this kind of error. Note ids seem to be unaffected so I didn't change them.