### PR TITLE
Add mediafile import from memory

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,6 +171,13 @@
 //!
 //! You should only put the filename (aka basename) and not the full path in the field; `<img src="images/image.jpg">` will *not* work. Media files should have unique filenames.
 //!
+//! ### Media files from memory
+//! If you want to add `media_files` from memory use [`Package::new_from_memory`] instead of [`Package::new`]:
+//! ```rust
+//! // ...
+//! let mut my_package = Package::new_from_memory(vec![deck], vec![MediaFile::new_from_bytes(&mp3_bytes, "sound.mp3"), MediaFile::new_from_bytes(&jpg_bytes, "image.jpg")])?;
+//! ```
+//! 
 //! ### sort_field
 //! Anki has a value for each `Note` called the `sort_field`. Anki uses this
 //! value to sort the cards in the Browse interface. Anki also is happier if

--- a/src/package.rs
+++ b/src/package.rs
@@ -17,7 +17,7 @@ use std::str::FromStr;
 
 /// `Package` to pack `Deck`s and `media_files` and write them to a `.apkg` file
 ///
-/// Example:
+/// # Example (media files on the filesystem):
 /// ```rust
 /// use genanki_rs::{Package, Deck, Note, Model, Field, Template};
 ///
@@ -41,6 +41,43 @@ use std::str::FromStr;
 /// let mut package = Package::new(vec![my_deck], vec!["sound.mp3", "images/image.jpg"])?;
 /// package.write_to_file("output.apkg")?;
 /// ```
+/// # Example (media files from memory):
+/// ```rust	
+/// use genanki_rs::{Package, Deck, Note, Model, Field, Template, MediaFile};
+
+/// const VALID_MP3: &[u8] =
+/// b"\xff\xe3\x18\xc4\x00\x00\x00\x03H\x00\x00\x00\x00LAME3.98.2\x00\x00\x00\
+/// \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\
+/// \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\
+/// \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
+/// 
+/// const VALID_JPG: &[u8] =
+/// b"\xff\xd8\xff\xdb\x00C\x00\x03\x02\x02\x02\x02\x02\x03\x02\x02\x02\x03\x03\
+/// \x03\x03\x04\x06\x04\x04\x04\x04\x04\x08\x06\x06\x05\x06\t\x08\n\n\t\x08\t\
+/// \t\n\x0c\x0f\x0c\n\x0b\x0e\x0b\t\t\r\x11\r\x0e\x0f\x10\x10\x11\x10\n\x0c\
+/// \x12\x13\x12\x10\x13\x0f\x10\x10\x10\xff\xc9\x00\x0b\x08\x00\x01\x00\x01\
+/// \x01\x01\x11\x00\xff\xcc\x00\x06\x00\x10\x10\x05\xff\xda\x00\x08\x01\x01\
+/// \x00\x00?\x00\xd2\xcf \xff\xd9";
+/// 
+/// let model = Model::new(
+/// 1607392319,
+/// "Simple Model",
+/// vec![
+///     Field::new("Question"),
+///     Field::new("Answer"),
+///     Field::new("MyMedia"),
+/// ],
+/// vec![Template::new("Card 1")
+///     .qfmt("{{Question}}{{Question}}<br>{{MyMedia}}")
+///     .afmt(r#"{{FrontSide}}<hr id="answer">{{Answer}}"#)],
+/// );
+/// let mut deck = Deck::new(1234, "Example Deck", "Example Deck with media");
+/// deck.add_note(Note::new(model.clone(), vec!["What is the capital of France?", "Paris", "[sound:sound.mp3]"])?);
+/// deck.add_note(Note::new(model.clone(), vec!["What is the capital of France?", "Paris", r#"<img src="image.jpg">"#])?);
+/// 
+/// let mut package = Package::new_from_memory(vec![deck], vec![MediaFile::new_from_bytes(VALID_MP3, "sound.mp3"), MediaFile::new_from_bytes(VALID_JPG, "image.jpg")])?;
+/// package.write_to_file("output.apkg")?;
+/// ```
 pub struct Package {
     decks: Vec<Deck>,
     media_files: Vec<MediaFile>,
@@ -49,7 +86,7 @@ pub struct Package {
 pub enum MediaFile {
     /// a path on the filesystem
     Path(PathBuf),
-    /// bytes from memory and a filename
+    /// bytes of the file and a filename
     Bytes(Vec<u8>, String),
 }
 impl MediaFile {
@@ -58,7 +95,7 @@ impl MediaFile {
         Self::Path(path.as_ref().to_path_buf())
     }
 
-    /// Create a new `MediaFile` from a path on the filesystem
+    /// Create a new `MediaFile` from a path on the filesystem using a `&str`
     pub fn new_from_file_path(path: &str) -> Result<Self, Error> {
         Ok(Self::Path(PathBuf::from_str(path)?))
     }


### PR DESCRIPTION
# Problem
The package creation currently only allows for media files to be read from the filesystem.
# Solution
The package now exposes a function to create mediafiles from memory: `new_from_memory`. 
To allow imports both from the filesystem and from memory, a new enum was introduced: `MediaFile`.
# Example usage
```rust
use genanki_rs::{Package, Deck, Note, Model, Field, Template, MediaFile};

const VALID_MP3: &[u8] =
    b"\xff\xe3\x18\xc4\x00\x00\x00\x03H\x00\x00\x00\x00LAME3.98.2\x00\x00\x00\
    \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\
    \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\
    \x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
const VALID_JPG: &[u8] =
    b"\xff\xd8\xff\xdb\x00C\x00\x03\x02\x02\x02\x02\x02\x03\x02\x02\x02\x03\x03\
    \x03\x03\x04\x06\x04\x04\x04\x04\x04\x08\x06\x06\x05\x06\t\x08\n\n\t\x08\t\
    \t\n\x0c\x0f\x0c\n\x0b\x0e\x0b\t\t\r\x11\r\x0e\x0f\x10\x10\x11\x10\n\x0c\
    \x12\x13\x12\x10\x13\x0f\x10\x10\x10\xff\xc9\x00\x0b\x08\x00\x01\x00\x01\
    \x01\x01\x11\x00\xff\xcc\x00\x06\x00\x10\x10\x05\xff\xda\x00\x08\x01\x01\
    \x00\x00?\x00\xd2\xcf \xff\xd9";

let model = Model::new(
    1607392319,
    "Simple Model",
    vec![
        Field::new("Question"),
        Field::new("Answer"),
        Field::new("MyMedia"),
    ],
    vec![Template::new("Card 1")
        .qfmt("{{Question}}{{Question}}<br>{{MyMedia}}")
        .afmt(r#"{{FrontSide}}<hr id="answer">{{Answer}}"#)],
);

let mut deck = Deck::new(1234, "Example Deck", "Example Deck with media");
deck.add_note(Note::new(model.clone(), vec!["What is the capital of France?", "Paris", "[sound:sound.mp3]"])?);
deck.add_note(Note::new(model.clone(), vec!["What is the capital of France?", "Paris", r#"<img src="image.jpg">"#])?);

let mut package = Package::new_from_memory(vec![deck], vec![MediaFile::new_from_bytes(VALID_MP3, "sound.mp3"), MediaFile::new_from_bytes(VALID_JPG, "image.jpg")])?;
package.write_to_file("output.apkg")?;
```
# Tests
Although I was unable to successfully run all tests locally, I have implemented a test for importing media files from memory that *should* pass.